### PR TITLE
Migrate to StandardSchemaV1 namespace

### DIFF
--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -26,7 +26,7 @@ export interface StandardSchemaV1<Input = unknown, Output = Input> {
     /**
      * Inferred types associated with the schema.
      */
-    readonly types?: Declaration<Input, Output> | undefined;
+    readonly types?: Types<Input, Output> | undefined;
   };
 }
 ```

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -4,7 +4,7 @@ A consortium of schema library authors have collaborated to craft a standard int
 
 ## The Interface
 
-The `StandardSchema` interface is a set of validation-related properties that must be defined under a key called `~standard`.
+The Standard Schema interface is a set of validation-related properties that must be defined under a key called `~standard`.
 
 ```ts
 export interface StandardSchemaV1<Input = unknown, Output = Input> {
@@ -43,7 +43,7 @@ Two parties are required for Standard Schema to work. First, the schema librarie
 
 ### Schema Library
 
-Schemas libraries that want to support Standard Schema must implement its interface. This includes adding the `~standard` property. To make this process easier, schema libraries can optionally extend their interface from the `StandardSchema` interface.
+Schemas libraries that want to support Standard Schema must implement its interface. This includes adding the `~standard` property. To make this process easier, schema libraries can optionally extend their interface from the `StandardSchemaV1` interface.
 
 > It doesn't matter whether your schema library returns plain objects, functions, or class instances. The only thing that matters is that the `~standard` property is defined somehow.
 
@@ -74,11 +74,11 @@ function string(message: string = "Invalid type"): StringSchema {
 }
 ```
 
-Instead of implementing the `StandardSchema` interface natively into your library code, you can also just add it on top and reuse your existing functions and methods within the `validate` function.
+Instead of implementing the `StandardSchemaV1` interface natively into your library code, you can also just add it on top and reuse your existing functions and methods within the `validate` function.
 
 ### Third Party
 
-Other than for schema library authors, we recommend third party authors to install the `@standard-schema/spec` package when implementing Standard Schema into their libraries. This package provides the `StandardSchema` interface and the `InferInput` and `InferOutput` utility types.
+Other than for schema library authors, we recommend third party authors to install the `@standard-schema/spec` package when implementing Standard Schema into their libraries. This package provides the `StandardSchemaV1` interface and the `InferInput` and `InferOutput` utility types.
 
 ```sh
 npm install @standard-schema/spec --save-dev  # npm
@@ -90,7 +90,7 @@ deno add jsr:@standard-schema/spec --dev      # deno
 
 > Alternatively, you can also copy and paste [the types](https://github.com/standard-schema/standard-schema/blob/main/packages/spec/src/index.ts) into your project.
 
-After that you can accept any schemas that implement the Standard Schema interface as part of your API. We recommend using a generic that extends the `StandardSchema` interface in most cases to be able to infer the type information of the schema.
+After that you can accept any schemas that implement the Standard Schema interface as part of your API. We recommend using a generic that extends the `StandardSchemaV1` interface in most cases to be able to infer the type information of the schema.
 
 ```ts
 import type { StandardSchemaV1 } from "@standard-schema/spec";
@@ -194,7 +194,6 @@ These are the libraries that have already implemented the Standard Schema interf
 - [tRPC](https://github.com/trpc/trpc): 🧙‍♀️ Move Fast and Break Nothing. End-to-end typesafe APIs made easy.
 
 ## Background
-
 
 ### The Problem
 

--- a/packages/spec/playground.ts
+++ b/packages/spec/playground.ts
@@ -1,1 +1,1 @@
-import type { v1 } from "./src/index.ts";
+import type { StandardSchemaV1 } from "./src/index.ts";

--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -3,24 +3,14 @@
  *
  * Root-level alias of StandardSchemaV1.Schema.
  */
-export type StandardSchemaV1<
-  Input = unknown,
-  Output = Input,
-> = StandardSchemaV1.Schema<Input, Output>;
+export type StandardSchemaV1<Input = unknown, Output = Input> = {
+  /**
+   * The Standard Schema properties.
+   */
+  readonly "~standard": StandardSchemaV1.Props<Input, Output>;
+};
 
 export declare namespace StandardSchemaV1 {
-  /**
-   * The Standard Schema interface.
-   *
-   * Equivalent to the root-level StandardSchemaV1 type.
-   */
-  export interface Schema<Input = unknown, Output = Input> {
-    /**
-     * The Standard Schema properties.
-     */
-    readonly "~standard": StandardSchemaV1.Props<Input, Output>;
-  }
-
   /**
    * The Standard Schema properties interface.
    */
@@ -42,7 +32,7 @@ export declare namespace StandardSchemaV1 {
     /**
      * Inferred types associated with the schema.
      */
-    readonly types?: Declaration<Input, Output> | undefined;
+    readonly types?: Types<Input, Output> | undefined;
   }
 
   /**
@@ -101,7 +91,7 @@ export declare namespace StandardSchemaV1 {
   /**
    * The base types interface of Standard Schema.
    */
-  export interface Declaration<Input = unknown, Output = Input> {
+  export interface Types<Input = unknown, Output = Input> {
     /**
      * The input type of the schema.
      */
@@ -125,4 +115,6 @@ export declare namespace StandardSchemaV1 {
   export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<
     Schema["~standard"]["types"]
   >["output"];
+
+  export {};
 }

--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -116,5 +116,6 @@ export declare namespace StandardSchemaV1 {
     Schema["~standard"]["types"]
   >["output"];
 
+  // biome-ignore lint/complexity/noUselessEmptyExport: needed for granular visibility control of TS namespace
   export {};
 }

--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -1,18 +1,30 @@
-export declare namespace v1 {
+/**
+ * The Standard Schema interface.
+ *
+ * Root-level alias of StandardSchemaV1.Schema.
+ */
+export type StandardSchemaV1<
+  Input = unknown,
+  Output = Input,
+> = StandardSchemaV1.Schema<Input, Output>;
+
+export declare namespace StandardSchemaV1 {
   /**
    * The Standard Schema interface.
+   *
+   * Equivalent to the root-level StandardSchemaV1 type.
    */
-  interface StandardSchema<Input = unknown, Output = Input> {
+  export interface Schema<Input = unknown, Output = Input> {
     /**
      * The Standard Schema properties.
      */
-    readonly "~standard": StandardSchemaProps<Input, Output>;
+    readonly "~standard": StandardSchemaV1.Props<Input, Output>;
   }
 
   /**
    * The Standard Schema properties interface.
    */
-  interface StandardSchemaProps<Input = unknown, Output = Input> {
+  export interface Props<Input = unknown, Output = Input> {
     /**
      * The version number of the standard.
      */
@@ -26,24 +38,22 @@ export declare namespace v1 {
      */
     readonly validate: (
       value: unknown,
-    ) => StandardResult<Output> | Promise<StandardResult<Output>>;
+    ) => Result<Output> | Promise<Result<Output>>;
     /**
      * Inferred types associated with the schema.
      */
-    readonly types?: StandardTypes<Input, Output> | undefined;
+    readonly types?: Declaration<Input, Output> | undefined;
   }
 
   /**
    * The result interface of the validate function.
    */
-  type StandardResult<Output> =
-    | StandardSuccessResult<Output>
-    | StandardFailureResult;
+  export type Result<Output> = SuccessResult<Output> | FailureResult;
 
   /**
    * The result interface if validation succeeds.
    */
-  interface StandardSuccessResult<Output> {
+  export interface SuccessResult<Output> {
     /**
      * The typed output value.
      */
@@ -57,17 +67,17 @@ export declare namespace v1 {
   /**
    * The result interface if validation fails.
    */
-  interface StandardFailureResult {
+  export interface FailureResult {
     /**
      * The issues of failed validation.
      */
-    readonly issues: ReadonlyArray<StandardIssue>;
+    readonly issues: ReadonlyArray<Issue>;
   }
 
   /**
    * The issue interface of the failure output.
    */
-  interface StandardIssue {
+  export interface Issue {
     /**
      * The error message of the issue.
      */
@@ -75,15 +85,13 @@ export declare namespace v1 {
     /**
      * The path of the issue, if any.
      */
-    readonly path?:
-      | ReadonlyArray<PropertyKey | StandardPathSegment>
-      | undefined;
+    readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
   }
 
   /**
    * The path segment interface of the issue.
    */
-  interface StandardPathSegment {
+  export interface PathSegment {
     /**
      * The key representing a path segment.
      */
@@ -93,7 +101,7 @@ export declare namespace v1 {
   /**
    * The base types interface of Standard Schema.
    */
-  interface StandardTypes<Input, Output> {
+  export interface Declaration<Input = unknown, Output = Input> {
     /**
      * The input type of the schema.
      */
@@ -107,14 +115,14 @@ export declare namespace v1 {
   /**
    * Infers the input type of a Standard Schema.
    */
-  type InferInput<Schema extends StandardSchema> = NonNullable<
+  export type InferInput<Schema extends StandardSchemaV1> = NonNullable<
     Schema["~standard"]["types"]
   >["input"];
 
   /**
    * Infers the output type of a Standard Schema.
    */
-  type InferOutput<Schema extends StandardSchema> = NonNullable<
+  export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<
     Schema["~standard"]["types"]
   >["output"];
 }

--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -1,7 +1,5 @@
 /**
  * The Standard Schema interface.
- *
- * Root-level alias of StandardSchemaV1.Schema.
  */
 export type StandardSchemaV1<Input = unknown, Output = Input> = {
   /**
@@ -89,7 +87,7 @@ export declare namespace StandardSchemaV1 {
   }
 
   /**
-   * The base types interface of Standard Schema.
+   * The Standard Schema types interface.
    */
   export interface Types<Input = unknown, Output = Input> {
     /**


### PR DESCRIPTION
Migrated types to a `StandardSchemaV1` namespace with a top-level alias as discussed.

The only additional change I made was to rename `Types` to `Declaration`. To me, `StandardSchemaV1.Types` sounds too ambiguous, whereas `Declaration` does a bit better of a job implying it's the declared types of a schema instance. We would lose the parallel between the property name and type name though, so could also consider renaming that to `declaration`. `types` doesn't feel as ambiguous as a property name, so could go either way on that one. If anyone feels strongly that `Types` is better, I'm open to changing it back.