### PR TITLE
docs: add GQLoom to third parties

### DIFF
--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -198,6 +198,7 @@ These are the libraries that have already implemented the Standard Schema interf
 
 ### Third Parties
 
+- [GQLoom](https://github.com/modevol-com/gqloom): Weave GraphQL schema and resolvers using Standard Schema.
 - [Nuxt UI](https://github.com/nuxt/ui): A UI Library for Modern Web Apps, powered by Vue & Tailwind CSS.
 - [TanStack Router](https://github.com/tanstack/router): A fully type-safe React router with built-in data fetching, stale-while revalidate caching and first-class search-param APIs.
 - [tRPC](https://github.com/trpc/trpc): 🧙‍♀️ Move Fast and Break Nothing. End-to-end typesafe APIs made easy.


### PR DESCRIPTION
I'm excited to introduce you to GQLoom.

[GQLoom](https://github.com/modevol-com/gqloom) is a code first GraphQL server-side framework. GQLoom weaves popular schema from the TypeScript ecosystem into GraphQL schema. Currently GQLoom has integrated valibot, zod, yup, prisma, and mikro-orm.

For schema from ORM, GQLoom also supports generation of CRUD APIs to simplify the development.

Thanks and praises to standard-schema, which makes GQLoom easier to maintain and provides an API with nicer development experience!

## Hello, World!

```ts
import { weave, resolver, query } from "@gqloom/core"
import { ValibotWeaver } from "@gqloom/valibot"
import * as v from "valibot"

const helloResolver = resolver({
  hello: query(v.string(), () => "world"),
})

export const schema = weave(ValibotWeaver, helloResolver)
```