### PR TITLE
docs: Add formwerk to third party libraries

### DIFF
--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -196,7 +196,7 @@ These are the libraries that have already implemented the Standard Schema interf
 - [TanStack Router](https://github.com/tanstack/router): A fully type-safe React router with built-in data fetching, stale-while revalidate caching and first-class search-param APIs.
 - [tRPC](https://github.com/trpc/trpc): 🧙‍♀️ Move Fast and Break Nothing. End-to-end typesafe APIs made easy.
 - [UploadThing](https://github.com/pingdotgg/uploadthing): File uploads for modern web devs
-- [Formwerk](https://github.com/formwerkjs/formwerk): Vue.js Composable Forms Library
+- [Formwerk](https://github.com/formwerkjs/formwerk): A Vue.js Framework for building high-quality, accessible, delightful forms.
 
 ## Background
 

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -190,13 +190,13 @@ These are the libraries that have already implemented the Standard Schema interf
 
 ### Third Parties
 
+- [Formwerk](https://github.com/formwerkjs/formwerk): A Vue.js Framework for building high-quality, accessible, delightful forms.
 - [GQLoom](https://github.com/modevol-com/gqloom): Weave GraphQL schema and resolvers using Standard Schema.
 - [Nuxt UI](https://github.com/nuxt/ui): A UI Library for Modern Web Apps, powered by Vue & Tailwind CSS.
 - [TanStack Form](https://github.com/TanStack/form): 🤖 Headless, performant, and type-safe form state management for TS/JS, React, Vue, Angular, Solid, and Lit.
 - [TanStack Router](https://github.com/tanstack/router): A fully type-safe React router with built-in data fetching, stale-while revalidate caching and first-class search-param APIs.
 - [tRPC](https://github.com/trpc/trpc): 🧙‍♀️ Move Fast and Break Nothing. End-to-end typesafe APIs made easy.
 - [UploadThing](https://github.com/pingdotgg/uploadthing): File uploads for modern web devs
-- [Formwerk](https://github.com/formwerkjs/formwerk): A Vue.js Framework for building high-quality, accessible, delightful forms.
 
 ## Background
 

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -196,6 +196,7 @@ These are the libraries that have already implemented the Standard Schema interf
 - [TanStack Router](https://github.com/tanstack/router): A fully type-safe React router with built-in data fetching, stale-while revalidate caching and first-class search-param APIs.
 - [tRPC](https://github.com/trpc/trpc): 🧙‍♀️ Move Fast and Break Nothing. End-to-end typesafe APIs made easy.
 - [UploadThing](https://github.com/pingdotgg/uploadthing): File uploads for modern web devs
+- [Formwerk](https://github.com/formwerkjs/formwerk): Vue.js Composable Forms Library
 
 ## Background
 


### PR DESCRIPTION
## What

Adds [Formwerk](https://formwerk.dev/) to the list of 3rd-party libraries that accepts a standard schema.