### PR TITLE
Add oRPC - Typesafe API's Made Simple 🪄

### DIFF
--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -180,7 +180,7 @@ async function validateInput<TSchema extends StandardSchemaV1>(
 
 ## Ecosystem
 
-These are the libraries that have already implemented the Standard Schema interface. Feel free to add your library to the list in ascending order by creating a pull request.
+These are the libraries that have already implemented the Standard Schema interface. Feel free to add your library to the list **in ascending order** by creating a pull request.
 
 ### Schema Libraries
 
@@ -193,11 +193,11 @@ These are the libraries that have already implemented the Standard Schema interf
 - [Formwerk](https://github.com/formwerkjs/formwerk): A Vue.js Framework for building high-quality, accessible, delightful forms.
 - [GQLoom](https://github.com/modevol-com/gqloom): Weave GraphQL schema and resolvers using Standard Schema.
 - [Nuxt UI](https://github.com/nuxt/ui): A UI Library for Modern Web Apps, powered by Vue & Tailwind CSS.
+- [oRPC](https://github.com/unnoq/orpc): Typesafe API's Made Simple 🪄
 - [TanStack Form](https://github.com/TanStack/form): 🤖 Headless, performant, and type-safe form state management for TS/JS, React, Vue, Angular, Solid, and Lit.
 - [TanStack Router](https://github.com/tanstack/router): A fully type-safe React router with built-in data fetching, stale-while revalidate caching and first-class search-param APIs.
 - [tRPC](https://github.com/trpc/trpc): 🧙‍♀️ Move Fast and Break Nothing. End-to-end typesafe APIs made easy.
 - [UploadThing](https://github.com/pingdotgg/uploadthing): File uploads for modern web devs
-- [oRPC](https://github.com/unnoq/orpc): Typesafe API's Made Simple 🪄
 
 ## Background
 

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -197,6 +197,7 @@ These are the libraries that have already implemented the Standard Schema interf
 - [TanStack Router](https://github.com/tanstack/router): A fully type-safe React router with built-in data fetching, stale-while revalidate caching and first-class search-param APIs.
 - [tRPC](https://github.com/trpc/trpc): 🧙‍♀️ Move Fast and Break Nothing. End-to-end typesafe APIs made easy.
 - [UploadThing](https://github.com/pingdotgg/uploadthing): File uploads for modern web devs
+- [oRPC](https://github.com/unnoq/orpc): Typesafe API's Made Simple 🪄
 
 ## Background
 


### PR DESCRIPTION
Thank you for this wonderful project! **oRPC** can now effortlessly support any schema that follows **standard schema**