### PR TITLE
Add Arri Schema to list of schema libraries

### DIFF
--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -184,6 +184,7 @@ These are the libraries that have already implemented the Standard Schema interf
 
 ### Schema Libraries
 
+- [Arri Schema](https://github.com/modiimedia/arri): Type safe validator and schema builder that can be compiled to other languages
 - [ArkType](https://github.com/arktypeio/arktype): TypeScript's 1:1 validator, optimized from editor to runtime ⛵
 - [Valibot](https://github.com/fabian-hiller/valibot): The modular and type safe schema library for validating structural data 🤖
 - [Zod](https://github.com/colinhacks/zod) (v3.24+): TypeScript-first schema validation with static type inference

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -184,8 +184,8 @@ These are the libraries that have already implemented the Standard Schema interf
 
 ### Schema Libraries
 
-- [Arri Schema](https://github.com/modiimedia/arri): Type safe validator and schema builder that can be compiled to other languages
 - [ArkType](https://github.com/arktypeio/arktype): TypeScript's 1:1 validator, optimized from editor to runtime ⛵
+- [Arri Schema](https://github.com/modiimedia/arri): Type safe validator and schema builder that can be compiled to other languages
 - [Valibot](https://github.com/fabian-hiller/valibot): The modular and type safe schema library for validating structural data 🤖
 - [Zod](https://github.com/colinhacks/zod) (v3.24+): TypeScript-first schema validation with static type inference
 


### PR DESCRIPTION
Thanks for your work on this project!

This PR adds `@arrirpc/schema` to the list of schema libraries. Arri RPC is unique in the sense that Arri Schemas can be [compiled to other languages](https://github.com/modiimedia/arri/tree/master/languages/ts/ts-schema#compiling-to-other-languages) using the Arri CLI. 

It's a monorepo that supports multiple programming languages, so I was unsure of whether to link the [repo url](https://github.com/modiimedia/arri/) or to link specifically to the [typescript schema builder](https://github.com/modiimedia/arri/tree/master/languages/ts/ts-schema) nested inside the repo.

My only concern about the later option is if the Arri codebase is refactored it'll break the link, but I suppose I can just open another PR in that case. I'll defer to your opinion concerning this.