### PR TITLE
chore: add `Regle` to the list of Third Parties

### DIFF
--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -199,6 +199,7 @@ These are the libraries that have already implemented the Standard Schema interf
 - [TanStack Router](https://github.com/tanstack/router): A fully type-safe React router with built-in data fetching, stale-while revalidate caching and first-class search-param APIs.
 - [tRPC](https://github.com/trpc/trpc): 🧙‍♀️ Move Fast and Break Nothing. End-to-end typesafe APIs made easy.
 - [UploadThing](https://github.com/pingdotgg/uploadthing): File uploads for modern web devs
+- [Regle](https://github.com/victorgarciaesgi/regle): Type safe model-based form validation library for Vue.js
 
 ## Background
 

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -195,11 +195,11 @@ These are the libraries that have already implemented the Standard Schema interf
 - [GQLoom](https://github.com/modevol-com/gqloom): Weave GraphQL schema and resolvers using Standard Schema.
 - [Nuxt UI](https://github.com/nuxt/ui): A UI Library for Modern Web Apps, powered by Vue & Tailwind CSS.
 - [oRPC](https://github.com/unnoq/orpc): Typesafe API's Made Simple 🪄
+- [Regle](https://github.com/victorgarciaesgi/regle): Type safe model-based form validation library for Vue.js
 - [TanStack Form](https://github.com/TanStack/form): 🤖 Headless, performant, and type-safe form state management for TS/JS, React, Vue, Angular, Solid, and Lit.
 - [TanStack Router](https://github.com/tanstack/router): A fully type-safe React router with built-in data fetching, stale-while revalidate caching and first-class search-param APIs.
 - [tRPC](https://github.com/trpc/trpc): 🧙‍♀️ Move Fast and Break Nothing. End-to-end typesafe APIs made easy.
 - [UploadThing](https://github.com/pingdotgg/uploadthing): File uploads for modern web devs
-- [Regle](https://github.com/victorgarciaesgi/regle): Type safe model-based form validation library for Vue.js
 
 ## Background
 


### PR DESCRIPTION
Hi! First of all congrats on this super cool initiative, it helped me a lot to reduce code to support both Zod and Valibot 💪 
It was such a breeze to be able to infer schema types with the same base.

## Library: Regle
### Description: Type safe model-based form validation library for Vue.js

Github: https://github.com/victorgarciaesgi/regle
Docs: https://reglejs.dev/

The latest version `0.7.0` now use `standard-schema` to support Zod & Valibot 👍  
Link to commit of the migration: https://github.com/victorgarciaesgi/regle/commit/fde8a15fb5737d0ceb84ed646219a1136264e934

Usage can be found here:
- Zod: https://reglejs.dev/integrations/zod
- Valibot: https://reglejs.dev/integrations/valibot