### PR TITLE
Readme: Add TypeMap

### DIFF
--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -112,12 +112,13 @@ The specification meets a few primary design objectives:
 
 These are the libraries that have already implemented the Standard Schema interface. (If you maintain a library that implements the spec, [create a PR](https://github.com/standard-schema/standard-schema/compare) to add yourself!)
 
-| Implementer | Version(s)           | Docs                                                             |
-| ----------- | -------------------- | ---------------------------------------------------------------- |
-| Zod         | 3.24.0+              | [zod.dev](https://zod.dev/)                                      |
-| Valibot     | v1.0 (including RCs) | [valibot.dev](https://valibot.dev/)                              |
-| ArkType     | v2.0+                | [arktype.io](https://arktype.io/)                                |
-| Arri Schema | v0.71.0+             | [github.com/modiimedia/arri](https://github.com/modiimedia/arri) |
+| Implementer | Version(s)           | Docs                                                                               |
+| ----------- | -------------------- | ---------------------------------------------------------------------------------- |
+| Zod         | 3.24.0+              | [zod.dev](https://zod.dev/)                                                        |
+| Valibot     | v1.0 (including RCs) | [valibot.dev](https://valibot.dev/)                                                |
+| ArkType     | v2.0+                | [arktype.io](https://arktype.io/)                                                  |
+| Arri Schema | v0.71.0+             | [github.com/modiimedia/arri](https://github.com/modiimedia/arri)                   |
+| TypeMap     | v0.8.0+              | [github.com/sinclairzx81/typemap](https://github.com/sinclairzx81/typemap)         |
 
 ## What tools / frameworks accept spec-compliant schemas?
 


### PR DESCRIPTION
This PR adds a new library named TypeMap to the readme implementers table. TypeMap implements Standard Schema via Compile. It also uses it for type library differentiation within the TS type system.

### Project Link

https://github.com/sinclairzx81/typemap

### Reference Example

[Example Link](https://www.typescriptlang.org/play/?moduleResolution=99&module=199#code/JYWwDg9gTgLgBAbzgYQuYAbApnAvnAMyjTgHIABAZ2ADsBjDAQ2CgHoYBPMLERsUgFAC6EGpXhQslAK4Z4AXhRowmLAAoABggFw4ADwBccGtJAAjLFAA0OuByMnzlm7oBeD0xagDcGgJQA2qQAfuKMNAAmjFARpAC6AHQAbowYwFEw6tq6hnAAjC52RgBMhe5wAMw+fkA)

```typescript
import { Compile } from '@sinclair/typemap'

const result = Compile(`{
  x: number,
  y: number,
  z: number
}`)['~standard'].validate({
  x: 1,
  y: 2,
  z: 3
})
```