### PR TITLE
docs: Add make-service to list of spec-compliant tools

### DIFF
--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -145,6 +145,7 @@ The following tools accept user-defined schemas conforming to the Standard Schem
 | [Regle](https://reglejs.dev/)                         | Type-safe model-based form validation library for Vue.js                                                                     | [PR](https://github.com/victorgarciaesgi/regle/pull/46)                |
 | [upfetch](https://github.com/L-Blondy/up-fetch)       | Tiny & composable fetch configuration tool with sensible defaults and built-in schema validation                             | [PR](https://github.com/L-Blondy/up-fetch/pull/11)                     |
 | [rest-client](https://github.com/logione/rest-client) | Ultra-lightweight and easy-to-use http(s) client for node.js supporting JSON and streams with no external dependencies       | [Docs](https://github.com/logione/rest-client)                         |
+| [make-service](https://github.com/gustavoguichard/make-service) | A set of utilities to improve the DX of native `fetch` to better interact with external APIs. | [PR](https://github.com/gustavoguichard/make-service/pull/57)                         |
 
 ## How can my schema library implement the spec?
 


### PR DESCRIPTION
`make-service` is a little library that improves the DX to deal with external APIs.
It was based only on Zod and from v4 on it will be based on standard schema spec:

```ts
import { makeService } from 'make-service'

const service = makeService("https://example.com/api", {
  headers: {
    Authorization: "Bearer 123",
  },
});

const response = await service.get("users/:id", { params: { id: 1 } })
const user = await response.json(userSchema);
//                                 ^ This is where we use the parsers
//     ^? UserType
```