### PR TITLE
docs: Add call-api to list of spec-compliant tools

### DIFF
--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -145,6 +145,7 @@ The following tools accept user-defined schemas conforming to the Standard Schem
 | [Regle](https://reglejs.dev/)                         | Type-safe model-based form validation library for Vue.js                                                                     | [PR](https://github.com/victorgarciaesgi/regle/pull/46)                |
 | [upfetch](https://github.com/L-Blondy/up-fetch)       | Tiny & composable fetch configuration tool with sensible defaults and built-in schema validation                             | [PR](https://github.com/L-Blondy/up-fetch/pull/11)                     |
 | [rest-client](https://github.com/logione/rest-client) | Ultra-lightweight and easy-to-use http(s) client for node.js supporting JSON and streams with no external dependencies       | [Docs](https://github.com/logione/rest-client)                         |
+| [call-api](https://github.com/zayne-labs/callapi)       | A lightweight fetching library packed with essential features - retries, interceptors, request deduplication and much more, all while still retaining a similar API surface with regular Fetch.                           | [PR](https://github.com/zayne-labs/call-api/pull/131)        
 
 ## How can my schema library implement the spec?
 


### PR DESCRIPTION
First off, thank you all so much for this wonderful creation! I've been holding back so long on allowing schemas due to burden of maintaining multiple adapters. 
But this just throws that hesitation away! I sincerely appreciate😁

As of v1.4.0, callApi implements the standard schema spec.👌

## Basic Usage

```ts
import { z } from 'zod'
import { callApi } from '@zayne-labs/callapi'
 
 const { data } = await callApi('https://example.com/users/1', {
    schemas: {
		data: z.object({
			name: z.string(),
			age: z.number(),
			address: z.string(),
	    })
	} ,
 })
 ```