### PR TITLE
Update 'integration' example snippet

### DIFF
--- a/packages/examples/integrate.ts
+++ b/packages/examples/integrate.ts
@@ -16,7 +16,7 @@ export async function standardValidate<T extends StandardSchemaV1>(
   if (result instanceof Promise) result = await result;
 
   // if the `issues` field exists, the validation failed
-  if (result.issues) {
+  if ("issues" in result) {
     throw new Error(JSON.stringify(result.issues, null, 2));
   }
 

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -224,7 +224,7 @@ export async function standardValidate<T extends StandardSchemaV1>(
   if (result instanceof Promise) result = await result;
 
   // if the `issues` field exists, the validation failed
-  if (result.issues) {
+  if ("issues" in result) {
     throw new Error(JSON.stringify(result.issues, null, 2));
   }
 


### PR DESCRIPTION
Hi

If strictNullChecks is false, it seems is not enough to check truthiness of an attribute to narrow the type.
But you can use "in" narrowing to make it work in this case

Proof:
![image](https://github.com/user-attachments/assets/f09b88c0-3125-46e0-829c-c5deebf32184)
![image](https://github.com/user-attachments/assets/95b41a76-0d69-4204-9c2a-ff66dadf072c)
