### PR TITLE
feat(web): add clickable anchor links to headings

### DIFF
--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -106,4 +106,8 @@ article {
     /* no line break */
     @apply whitespace-nowrap;
   }
+
+  :is(h2, h3, h4, h5, h6) a.header-anchor {
+    @apply no-underline text-inherit hover:text-gray-300 transition-colors;
+  }
 }

--- a/packages/web/lib/markdown.ts
+++ b/packages/web/lib/markdown.ts
@@ -30,6 +30,7 @@ async function initMarkdownParser() {
 
       return slug;
     },
+    permalink: AnchorPlugin.permalink.headerLink(),
   });
   globalThis.md = md;
   return md;


### PR DESCRIPTION
# Add Clickable Anchor Links to Headings

## Summary
Implements clickable anchor links for all headings (h2-h6) on the documentation website, allowing users to share direct links to specific sections.

## Changes
- Configure `markdown-it-anchor` to wrap heading text in anchor links
- Add CSS styles for heading link hover effects