### PR TITLE
docs: typo fix - sometimes the ~standard.validate() function is called ~validate

### DIFF
--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -316,7 +316,7 @@ Thus, these symbol keys don't get sorted to the bottom of the autocomplete list,
 
 ### How to only allow synchronous validation?
 
-The `~validate` function might return a synchronous value _or_ a `Promise`. If you only accept synchronous validation, you can simply throw an error if the returned value is an instance of `Promise`. Libraries are encouraged to preferentially use synchronous validation whenever possible.
+The `~standard.validate()` function might return a synchronous value _or_ a `Promise`. If you only accept synchronous validation, you can simply throw an error if the returned value is an instance of `Promise`. Libraries are encouraged to preferentially use synchronous validation whenever possible.
 
 ```ts
 import type {StandardSchemaV1} from '@standard-schema/spec';

--- a/packages/web/index.md
+++ b/packages/web/index.md
@@ -262,7 +262,7 @@ By contrast, declaring the symbol externally makes it "nominally typed". This me
 
 ### What should I do if I only accept synchronous validation?
 
-The `~validate` function does not necessarily have to return a `Promise`. If you only accept synchronous validation, you can simply throw an error if the returned value is an instance of the `Promise` class.
+The `~standard.validate()` function does not necessarily have to return a `Promise`. If you only accept synchronous validation, you can simply throw an error if the returned value is an instance of the `Promise` class.
 
 ```ts
 import type { StandardSchemaV1 } from "@standard-schema/spec";


### PR DESCRIPTION
Twice this function is called `~validate` and twice it's called `~standard.validate()` - the latter is the correct one.