### PR TITLE
Add Tako to compatible tools list in README

### DIFF
--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -197,6 +197,7 @@ The following tools accept user-defined schemas conforming to the Standard Schem
 | [Inngest](https://www.inngest.com)                                            | Event-driven durable workflow engine that runs on any cloud                                                                           | [Docs](https://www.inngest.com/docs/reference/client/create#defining-event-payload-types)             |
 | [BUPKIS](https://github.com/boneskull/bupkis)                                 | Uncommonly extensible assertions for the beautiful people                                                                             | [Docs](https://bupkis.zip)                                                                            |
 | [Fragno](https://fragno.dev)                                                  | Build framework-agnostic TypeScript libraries that embed backend and frontend logic in user applications                              | [Docs](https://fragno.dev/docs/for-library-authors/features/route-definition#input-schema)            |
+| [Tako](https://takojs.github.io/)                                             | A CLI framework that works on any JavaScript runtime                                                                                  | [Docs](https://github.com/takojs/tako/blob/main/README.md)                                            |
 
 ## How can my schema library implement the spec?
 


### PR DESCRIPTION
Hello everyone,

Tako is a CLI framework that works on any JavaScript runtime.

<details>
<summary>Example</summary>

This example demonstrates Standard Schema validation with Valibot in a command specific to the Deno runtime.

```typescript
#!/usr/bin/env deno
// deno-lint-ignore-file no-import-prefix no-unversioned-import
// @ts-ignore: Required JSR import syntax
import { middleware as m, Tako } from "jsr:@takojs/tako";
// @ts-ignore: Required JSR import syntax
import type { TakoArgs } from "jsr:@takojs/tako";
// @ts-ignore: Required JSR import syntax
import * as v from "jsr:@valibot/valibot";

const helloSchema = v.object({
  values: v.object({
    name: v.picklist(["World", "Tako"]),
  }),
});

const helloValidation = m.v("scriptArgs", {}, helloSchema);

const helloArgs: TakoArgs = {
  config: {
    options: {
      name: {
        type: "string",
        short: "n",
        default: "World",
      },
    },
  },
  metadata: {
    help: "Prints a greeting.",
    options: {
      name: {
        help: "Your name.",
      },
    },
  },
};

const rootArgs: TakoArgs = {
  metadata: {
    version: "0.1.0",
    help: "Untitled",
  },
};

const tako = new Tako();

tako.command("hello", helloArgs, helloValidation, (c) => {
  const { values } = c.scriptArgs;
  c.print({ message: `Hello, ${values.name}!` });
});

await tako.cli(rootArgs);
```

```bash
$ deno main.ts hello
Hello, World!

$ deno main.ts hello -n Tako
Hello, Tako!

$ deno main.ts hello -n Alice
Error: Validation failed.
[...]

  Try '-h, --help' for help.
```

</details>

Thanks,
