### PR TITLE
add `@apollo/graphql-standard-schema` to implementing libraries

### DIFF
--- a/packages/spec/json-schema.md
+++ b/packages/spec/json-schema.md
@@ -161,6 +161,7 @@ The answer to this question is a little more nuanced than with regular _Standard
 | [ArkType](https://arktype.io/) | v2.1.28    | [PR](https://github.com/arktypeio/arktype/pull/1558)   |                                                                           | [#](#arktype)  |
 | [Valibot](https://valibot.dev) | v1.2       | [PR](https://github.com/open-circle/valibot/pull/1372) | via `toStandardJsonSchema()` in `@valibot/to-json-schema` package (v1.5+) | [#](#valibot)  |
 | [Zod Mini](https://zod.dev)    | v4.2+      | [PR](https://github.com/colinhacks/zod/pull/5477)      | via `z.toJSONSchema()`                                                    | [#](#zod-mini) |
+| [GraphQL Standard Schema](https://github.com/apollographql/graphql-standard-schema) | v0.2.0+    | [PR](https://github.com/apollographql/graphql-standard-schema/pull/8) | | [#](#graphql-standard-schema) |
 
 ## Usage
 
@@ -197,6 +198,20 @@ toStandardJsonSchema(v.string()) satisfies StandardJSONSchemaV1; // ✅
 import * as z from 'zod/mini';
 
 z.toJSONSchema(z.string()) satisfies StandardJSONSchemaV1; // ✅
+```
+
+### GraphQL Standard Schema
+
+```ts
+import { GraphQLStandardSchemaGenerator } from "@apollo/graphql-standard-schema";
+
+const generator = new GraphQLStandardSchemaGenerator({ schema, scalarTypes });
+const fragmentSchema = generator.getFragmentSchema(
+  gql`fragment UserDetails on User { id name }`
+);
+fragmentSchema satisfies StandardJSONSchemaV1; // ✅
+fragmentSchema.serialize satisfies StandardJSONSchemaV1; // ✅
+fragmentSchema.deserialize satisfies StandardJSONSchemaV1; // ✅
 ```
 
 ## What tools / frameworks accept spec-compliant schemas?

--- a/packages/spec/schema.md
+++ b/packages/spec/schema.md
@@ -144,6 +144,7 @@ These are the libraries that have already implemented the Standard Schema interf
 | [jsonv-ts](https://github.com/dswbx/jsonv-ts)                                      | v0.3.0+    | [PR](https://github.com/dswbx/jsonv-ts/pull/7)                                                             |
 | [Evolu](https://github.com/evoluhq/evolu)                                          | v6.0.1+    | [PR](https://github.com/evoluhq/evolu/pull/605)                                                            |
 | [zeed](https://github.com/holtwick/zeed)                                           | v1.1.0+    | [Commit](https://github.com/holtwick/zeed/commit/05fb980df7ed0722f45a417bad8f1560195c7e1b)                 |
+| [GraphQL Standard Schema](https://github.com/apollographql/graphql-standard-schema)| v0.1.0+    | from the start | 
 
 ## What tools / frameworks accept spec-compliant schemas?
 


### PR DESCRIPTION
Standard JSON Schema is out, so I can finally make this PR 🎉 

The library focuses on creation of validation schemas (runtime and JSON), mainly for use with AI, to describe "graphql shapes" to AI, either for tool calls, or for AI to create GraphQL-shaped responses.