### PR TITLE
docs(spec/json-schema): add GQLoom to Integrator

### DIFF
--- a/packages/spec/json-schema.md
+++ b/packages/spec/json-schema.md
@@ -226,6 +226,7 @@ When creating a PR to add your tool, please add a new row to the table below wit
 
 | Integrator | Description | Link |
 | ---------- | ----------- | ---- |
+| [GQLoom](https://gqloom.dev/) | Weave GraphQL schema and resolvers using Standard Schema | [PR](https://github.com/modevol-com/gqloom/pull/242) |
 
 ## FAQ
 


### PR DESCRIPTION
## GQLoom Support for Standard JSON Schema

[GQLoom](https://gqloom.dev/) is a TypeScript-first GraphQL framework that enables developers to build GraphQL APIs using their favorite validation libraries (Zod, Valibot, Yup, etc.) and ORMs (Prisma, Drizzle, MikroORM) with minimal boilerplate.

### Implementation

GQLoom now supports **Standard JSON Schema** through `@gqloom/json`, which acts as a universal converter for any library implementing the Standard JSON Schema specification. This enables seamless integration with libraries like ArkType and TypeBox without requiring custom adapters.

### Example

```typescript
import { query, resolver, weave } from "@gqloom/core"
import { JSONWeaver } from "@gqloom/json"
import { type } from "arktype"

const Cat = type({ name: "string" })
const resolver = resolver({
  cat: query(Cat).resolve(() => ({ name: "Lue" }))
})

const schema = weave(JSONWeaver, resolver)
```

### Related Links

- Website: https://gqloom.dev/
- Repository: https://github.com/modevol-com/gqloom
- Implementation PR: https://github.com/modevol-com/gqloom/pull/242