### PR TITLE
Add Raptor to the list of available validation libraries and compliant frameworks.

### DIFF
--- a/packages/spec/json-schema.md
+++ b/packages/spec/json-schema.md
@@ -164,7 +164,6 @@ The answer to this question is a little more nuanced than with regular _Standard
 | [GraphQL Standard Schema](https://github.com/apollographql/graphql-standard-schema) | v0.2.0+    | [PR](https://github.com/apollographql/graphql-standard-schema/pull/8) | | [#](#graphql-standard-schema) |
 | [stnl](https://github.com/re-utils/stnl) | v2.1+ | [Commit](https://github.com/re-utils/stnl/commit/3faa7126b15c69e668e242e3bf93ea7fa9c25772) | via `toStandardJSONSchema.v1()` | [#](#stnl) |
 | [VineJS](https://github.com/vinejs/vine) | v4.3.0+ | [PR](https://github.com/vinejs/vine/pull/139) | via `validator['~standard'].jsonSchema.input()`
-| [Raptor (Validator)](https://raptorjs.com)         | v0.9.0+      | [PR](https://github.com/raptor-js/validator/releases/tag/0.9.0)      | `schema({ name: rules<string>("required\|string") })` | [#](https://raptorjs.com/docs/validation)
 
 ## Usage
 
@@ -223,28 +222,6 @@ fragmentSchema.deserialize satisfies StandardJSONSchemaV1; // ✅
 import { t, toStandardJSONSchema } from 'stnl';
 
 toStandardJSONSchema.v1(t.string) satisfies StandardJSONSchemaV1; // ✅
-```
-
-### Raptor
-
-```ts
-import { Context } from "@raptor/framework";
-import { schema, rules } from "@raptor/validator";
- 
-app.use(async (context: Context) => {
-  const { request, response } = context;
-
-  const userSchema = schema({
-    name: rules<string>("required|string|min:2|max:50"),
-    email: rules<string>("required|email"),
-    age: rules<number>("required|integer|min:18"),
-    subscribed: rules<boolean>("boolean")
-  });
- 
-  const data = await context.request.validate(userSchema);
-	
-  return data;
-});
 ```
 
 ## What tools / frameworks accept spec-compliant schemas?

--- a/packages/spec/json-schema.md
+++ b/packages/spec/json-schema.md
@@ -262,6 +262,7 @@ When creating a PR to add your tool, please add a new row to the table below wit
 | [xsAI](https://github.com/moeru-ai/xsai) | Extra-small AI SDK | [PR](https://github.com/moeru-ai/xsai/pull/238) |
 | [GQLoom](https://gqloom.dev/) | Weave GraphQL schema and resolvers using Standard Schema | [PR](https://github.com/modevol-com/gqloom/pull/242) |
 | [@restatedev/restate-sdk](https://github.com/restatedev/sdk-typescript/) | Durable functions and agents with typesafe interfaces & clients validation | [Docs](https://docs.restate.dev/develop/ts/serialization) |
+| [Raptor](https://raptorjs.com) | A lightweight middleware framework for Deno, Bun & Node.js | [Docs](https://raptorjs.com/docs) |
 
 ## FAQ
 

--- a/packages/spec/json-schema.md
+++ b/packages/spec/json-schema.md
@@ -239,7 +239,6 @@ When creating a PR to add your tool, please add a new row to the table below wit
 | [xsAI](https://github.com/moeru-ai/xsai) | Extra-small AI SDK | [PR](https://github.com/moeru-ai/xsai/pull/238) |
 | [GQLoom](https://gqloom.dev/) | Weave GraphQL schema and resolvers using Standard Schema | [PR](https://github.com/modevol-com/gqloom/pull/242) |
 | [@restatedev/restate-sdk](https://github.com/restatedev/sdk-typescript/) | Durable functions and agents with typesafe interfaces & clients validation | [Docs](https://docs.restate.dev/develop/ts/serialization) |
-| [Raptor](https://raptorjs.com) | A lightweight middleware framework for Deno, Bun & Node.js | [Docs](https://raptorjs.com/docs) |
 
 ## FAQ
 

--- a/packages/spec/json-schema.md
+++ b/packages/spec/json-schema.md
@@ -164,6 +164,7 @@ The answer to this question is a little more nuanced than with regular _Standard
 | [GraphQL Standard Schema](https://github.com/apollographql/graphql-standard-schema) | v0.2.0+    | [PR](https://github.com/apollographql/graphql-standard-schema/pull/8) | | [#](#graphql-standard-schema) |
 | [stnl](https://github.com/re-utils/stnl) | v2.1+ | [Commit](https://github.com/re-utils/stnl/commit/3faa7126b15c69e668e242e3bf93ea7fa9c25772) | via `toStandardJSONSchema.v1()` | [#](#stnl) |
 | [VineJS](https://github.com/vinejs/vine) | v4.3.0+ | [PR](https://github.com/vinejs/vine/pull/139) | via `validator['~standard'].jsonSchema.input()`
+| [Raptor (Validator)](https://raptorjs.com)         | v0.9.0+      | [PR](https://github.com/raptor-js/validator/releases/tag/0.9.0)      | `schema({ name: rules<string>("required\|string") })` | [#](https://raptorjs.com/docs/validation)
 
 ## Usage
 
@@ -222,6 +223,28 @@ fragmentSchema.deserialize satisfies StandardJSONSchemaV1; // ✅
 import { t, toStandardJSONSchema } from 'stnl';
 
 toStandardJSONSchema.v1(t.string) satisfies StandardJSONSchemaV1; // ✅
+```
+
+### Raptor
+
+```ts
+import { Context } from "@raptor/framework";
+import { schema, rules } from "@raptor/validator";
+ 
+app.use(async (context: Context) => {
+  const { request, response } = context;
+
+  const userSchema = schema({
+    name: rules<string>("required|string|min:2|max:50"),
+    email: rules<string>("required|email"),
+    age: rules<number>("required|integer|min:18"),
+    subscribed: rules<boolean>("boolean")
+  });
+ 
+  const data = await context.request.validate(userSchema);
+	
+  return data;
+});
 ```
 
 ## What tools / frameworks accept spec-compliant schemas?

--- a/packages/spec/schema.md
+++ b/packages/spec/schema.md
@@ -211,7 +211,7 @@ The following tools accept user-defined schemas conforming to the Standard Schem
 | [@zap-studio/fetch](https://github.com/zap-studio/monorepo)                   | A type-safe fetch wrapper with Standard Schema validation                                                                             | [Docs](https://www.zapstudio.dev/packages/fetch)                                                      |
 | [@restatedev/restate-sdk](https://github.com/restatedev/sdk-typescript/)      | Durable functions and agents with typesafe interfaces & clients validation                                                            | [Docs](https://docs.restate.dev/develop/ts/serialization)                                             |
 | [WireTyped](https://github.com/kasperrt/wiretyped)                            | Universal fetch-based, typed HTTP client with error-first ergonomics, retries, caching, SSE, and Standard Schema validation           | [Docs](https://wiretyped.io/)      
-| [Raptor](https://raptorjs.com)                            | A lightweight middleware framework for Deno, Bun & Node.js | [Docs](https://wiretyped.io/)                                                                        |
+| [Raptor](https://raptorjs.com) | A lightweight middleware framework for Deno, Bun & Node.js | [Docs](https://raptorjs.com/docs) |
 
 <!-- ## How can my schema library implement the spec?
 

--- a/packages/spec/schema.md
+++ b/packages/spec/schema.md
@@ -144,7 +144,7 @@ These are the libraries that have already implemented the Standard Schema interf
 | [zeed](https://github.com/holtwick/zeed)                                           | v1.1.0+    | [Commit](https://github.com/holtwick/zeed/commit/05fb980df7ed0722f45a417bad8f1560195c7e1b)                 |
 | [GraphQL Standard Schema](https://github.com/apollographql/graphql-standard-schema)| v0.1.0+    | from the start                                                                                             |
 | [VineJS](https://github.com/vinejs/vine)                                           | v4.0.0+    | [Commit](https://github.com/vinejs/vine/commit/768beed3a6b0230b1fb1f340615c8b880c98515a)                   |
-| [validate.js](https://github.com/jakelazaroff/validate.js)                         | v0.1.0+    | from the start 
+| [validate.js](https://github.com/jakelazaroff/validate.js)                         | v0.1.0+    | from the start
 | [Raptor (Validator)](https://raptorjs.com)         | v0.9.0+      | [PR](https://github.com/raptor-js/validator/releases/tag/0.9.0)
 
 ## What tools / frameworks accept spec-compliant schemas?
@@ -210,7 +210,7 @@ The following tools accept user-defined schemas conforming to the Standard Schem
 | [Tako](https://takojs.github.io/)                                             | A CLI framework that works on any JavaScript runtime                                                                                  | [Docs](https://github.com/takojs/tako/blob/main/README.md)                                            |
 | [@zap-studio/fetch](https://github.com/zap-studio/monorepo)                   | A type-safe fetch wrapper with Standard Schema validation                                                                             | [Docs](https://www.zapstudio.dev/packages/fetch)                                                      |
 | [@restatedev/restate-sdk](https://github.com/restatedev/sdk-typescript/)      | Durable functions and agents with typesafe interfaces & clients validation                                                            | [Docs](https://docs.restate.dev/develop/ts/serialization)                                             |
-| [WireTyped](https://github.com/kasperrt/wiretyped)                            | Universal fetch-based, typed HTTP client with error-first ergonomics, retries, caching, SSE, and Standard Schema validation           | [Docs](https://wiretyped.io/)      
+| [WireTyped](https://github.com/kasperrt/wiretyped)                            | Universal fetch-based, typed HTTP client with error-first ergonomics, retries, caching, SSE, and Standard Schema validation           | [Docs](https://wiretyped.io/)
 | [Raptor](https://raptorjs.com) | A lightweight middleware framework for Deno, Bun & Node.js | [Docs](https://raptorjs.com/docs) |
 
 <!-- ## How can my schema library implement the spec?

--- a/packages/spec/schema.md
+++ b/packages/spec/schema.md
@@ -144,7 +144,8 @@ These are the libraries that have already implemented the Standard Schema interf
 | [zeed](https://github.com/holtwick/zeed)                                           | v1.1.0+    | [Commit](https://github.com/holtwick/zeed/commit/05fb980df7ed0722f45a417bad8f1560195c7e1b)                 |
 | [GraphQL Standard Schema](https://github.com/apollographql/graphql-standard-schema)| v0.1.0+    | from the start                                                                                             |
 | [VineJS](https://github.com/vinejs/vine)                                           | v4.0.0+    | [Commit](https://github.com/vinejs/vine/commit/768beed3a6b0230b1fb1f340615c8b880c98515a)                   |
-| [validate.js](https://github.com/jakelazaroff/validate.js)                         | v0.1.0+    | from the start                                                                                             |
+| [validate.js](https://github.com/jakelazaroff/validate.js)                         | v0.1.0+    | from the start 
+| [Raptor (Validator)](https://raptorjs.com)         | v0.9.0+      | [PR](https://github.com/raptor-js/validator/releases/tag/0.9.0)
 
 ## What tools / frameworks accept spec-compliant schemas?
 
@@ -209,7 +210,8 @@ The following tools accept user-defined schemas conforming to the Standard Schem
 | [Tako](https://takojs.github.io/)                                             | A CLI framework that works on any JavaScript runtime                                                                                  | [Docs](https://github.com/takojs/tako/blob/main/README.md)                                            |
 | [@zap-studio/fetch](https://github.com/zap-studio/monorepo)                   | A type-safe fetch wrapper with Standard Schema validation                                                                             | [Docs](https://www.zapstudio.dev/packages/fetch)                                                      |
 | [@restatedev/restate-sdk](https://github.com/restatedev/sdk-typescript/)      | Durable functions and agents with typesafe interfaces & clients validation                                                            | [Docs](https://docs.restate.dev/develop/ts/serialization)                                             |
-| [WireTyped](https://github.com/kasperrt/wiretyped)                            | Universal fetch-based, typed HTTP client with error-first ergonomics, retries, caching, SSE, and Standard Schema validation           | [Docs](https://wiretyped.io/)                                                                         |
+| [WireTyped](https://github.com/kasperrt/wiretyped)                            | Universal fetch-based, typed HTTP client with error-first ergonomics, retries, caching, SSE, and Standard Schema validation           | [Docs](https://wiretyped.io/)      
+| [Raptor](https://raptorjs.com)                            | A lightweight middleware framework for Deno, Bun & Node.js | [Docs](https://wiretyped.io/)                                                                        |
 
 <!-- ## How can my schema library implement the spec?
 

--- a/packages/web/index.md
+++ b/packages/web/index.md
@@ -205,6 +205,7 @@ These are the libraries that have already implemented the Standard Schema interf
 - [ArkType](https://github.com/arktypeio/arktype): TypeScript's 1:1 validator, optimized from editor to runtime ⛵
 - [Valibot](https://github.com/fabian-hiller/valibot): The modular and type safe schema library for validating structural data 🤖
 - [Zod](https://github.com/colinhacks/zod) (v3.24+): TypeScript-first schema validation with static type inference
+- [Raptor (Validator)](https://raptorjs.com/docs/validation) (v0.9.0+): An elegant, type-safe validation library for Raptor (and beyond).
 
 ### Third Parties
 


### PR DESCRIPTION
The following pull request adds [Raptor](https://raptorjs.com) Validator package (v0.9.0+) and Framework to the list of schema compliant validation libraries and supporting frameworks.

- [x] Full supporting documentation: https://raptorjs.com/docs/validation
- [x] Introducing pull request: https://github.com/raptor-js/validator/releases/tag/0.9.0