### PR TITLE
Add Sury to Standard JSON Schema implementers

### DIFF
--- a/packages/spec/json-schema.md
+++ b/packages/spec/json-schema.md
@@ -164,6 +164,7 @@ The answer to this question is a little more nuanced than with regular _Standard
 | [GraphQL Standard Schema](https://github.com/apollographql/graphql-standard-schema) | v0.2.0+    | [PR](https://github.com/apollographql/graphql-standard-schema/pull/8) | | [#](#graphql-standard-schema) |
 | [stnl](https://github.com/re-utils/stnl) | v2.1+ | [Commit](https://github.com/re-utils/stnl/commit/3faa7126b15c69e668e242e3bf93ea7fa9c25772) | via `toStandardJSONSchema.v1()` | [#](#stnl) |
 | [VineJS](https://github.com/vinejs/vine) | v4.3.0+ | [PR](https://github.com/vinejs/vine/pull/139) | via `validator['~standard'].jsonSchema.input()`
+| [Sury](https://github.com/DZakh/sury) | v11.0.0-alpha.10+ | [PR](https://github.com/DZakh/sury/pull/267) | via `S.enableStandardJSONSchema()` | [#](#sury) |
 
 ## Usage
 
@@ -222,6 +223,16 @@ fragmentSchema.deserialize satisfies StandardJSONSchemaV1; // ✅
 import { t, toStandardJSONSchema } from 'stnl';
 
 toStandardJSONSchema.v1(t.string) satisfies StandardJSONSchemaV1; // ✅
+```
+
+### Sury
+
+```ts
+import * as S from 'sury';
+
+S.enableStandardJSONSchema();
+
+S.string satisfies StandardJSONSchemaV1; // ✅
 ```
 
 ## What tools / frameworks accept spec-compliant schemas?


### PR DESCRIPTION
This PR adds Sury to the list of libraries that support the Standard JSON Schema specification.

## Summary
Documents Sury's support for Standard JSON Schema by adding it to the implementation table and providing a usage example.

## Changes
- Added Sury (v11.0.0-alpha.10+) to the implementations table with reference to [PR #267](https://github.com/DZakh/sury/pull/267)
- Included usage documentation showing how to enable Standard JSON Schema support via `S.enableStandardJSONSchema()`
- Added a code example demonstrating that Sury schemas satisfy the `StandardJSONSchemaV1` type after enabling the feature

## Details
The implementation allows users to leverage Sury's validation capabilities with Standard JSON Schema by calling `S.enableStandardJSONSchema()` before using schema objects, making them compatible with the spec.
